### PR TITLE
Fix MixinShoulderParrotFeatureRenderer

### DIFF
--- a/common/src/main/java/traben/entity_texture_features/mixin/entity/renderer/feature/MixinShoulderParrotFeatureRenderer.java
+++ b/common/src/main/java/traben/entity_texture_features/mixin/entity/renderer/feature/MixinShoulderParrotFeatureRenderer.java
@@ -38,6 +38,7 @@ public abstract class MixinShoulderParrotFeatureRenderer<T extends PlayerEntity>
     @Inject(method = "method_17958(Lnet/minecraft/client/util/math/MatrixStack;ZLnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/nbt/NbtCompound;Lnet/minecraft/client/render/VertexConsumerProvider;IFFFFLnet/minecraft/entity/EntityType;)V",
             at = @At(value = "HEAD"))
     private void etf$alterEntity(MatrixStack matrixStack, boolean bl, PlayerEntity playerEntity, NbtCompound nbtCompound, VertexConsumerProvider vertexConsumerProvider, int i, float f, float g, float h, float j, EntityType<?> type, CallbackInfo ci) {
+        entity_texture_features$parrotNBT = nbtCompound;
         if (entity_texture_features$parrotNBT != null) {
 
             etf$heldEntity = ETFRenderContext.getCurrentEntity();
@@ -59,12 +60,4 @@ public abstract class MixinShoulderParrotFeatureRenderer<T extends PlayerEntity>
         entity_texture_features$parrotNBT = null;
         etf$heldEntity = null;
     }
-
-    @Inject(method = "method_17958(Lnet/minecraft/client/util/math/MatrixStack;ZLnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/nbt/NbtCompound;Lnet/minecraft/client/render/VertexConsumerProvider;IFFFFLnet/minecraft/entity/EntityType;)V",
-            at = @At(value = "HEAD"))
-    private <M extends Entity> void etf$getNBT(MatrixStack matrixStack, boolean bl, PlayerEntity playerEntity, NbtCompound nbtCompound, VertexConsumerProvider vertexConsumerProvider, int i, float f, float g, float h, float j, EntityType<M> type, CallbackInfo ci) {
-        entity_texture_features$parrotNBT = nbtCompound;
-    }
 }
-
-


### PR DESCRIPTION
Currently parrots on shoulders aren't getting random textures, seemingly because `etf$getNBT` and `etf$alterEntity` get injected in the wrong order, meaning `entity_texture_features$parrotNBT` is always null when it's checked and parrots get ignored. These injects to same method can be merged to make sure the order is correct.