### PR TITLE
Remove exception that is thrown on servers

### DIFF
--- a/forge/src/main/java/traben/entity_texture_features/forge/ETFClientForge.java
+++ b/forge/src/main/java/traben/entity_texture_features/forge/ETFClientForge.java
@@ -32,9 +32,6 @@ public class ETFClientForge {
 
             ModLoadingContext.get().registerExtensionPoint(IExtensionPoint.DisplayTest.class, () -> new IExtensionPoint.DisplayTest(() -> IExtensionPoint.DisplayTest.IGNORESERVERONLY, (a, b) -> true));
             ETF.start();
-        } else {
-
-            throw new UnsupportedOperationException("Attempting to load a clientside only mod on the server, refusing");
         }
     }
 

--- a/neoforge/src/main/java/traben/entity_texture_features/neoforge/ETFClientNeoForge.java
+++ b/neoforge/src/main/java/traben/entity_texture_features/neoforge/ETFClientNeoForge.java
@@ -47,8 +47,6 @@ public class ETFClientNeoForge {
             }
             ETF.start();
 
-        } else {
-            throw new UnsupportedOperationException("Attempting to load a clientside only mod on the server, refusing");
         }
     }
     #if MC >= MC_21


### PR DESCRIPTION
This PR removes the exception that is thrown when ETF is loaded on a server and therefore fixes #274.
Without this, the server launches without any errors, even if ETF is installed.

According to [the forge documentation](https://docs.minecraftforge.net/en/1.21.x/concepts/sides/#writing-one-sided-mods) one-sided mods should still work on the incorrect side.

> Basically, if your mod is loaded on the wrong side, it should simply do nothing, listen to no events, and so on.
